### PR TITLE
feat: add replay downloader to get the replay file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,20 @@
+.idea
+.env
+.env.testing
+.vscode
+vendor
+*.test
+*.out
+*.so
+*.dll
+*.dylib
+.DS_Store
+build
+proto
+application.yaml
+
+# exception
+!Dockerfile.test
+!application.test.yaml
+
+db/schema.sql

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
-.idea
 .env
 .env.testing
 .vscode
@@ -11,10 +10,7 @@ vendor
 .DS_Store
 build
 proto
-application.yaml
+
 
 # exception
 !Dockerfile.test
-!application.test.yaml
-
-db/schema.sql

--- a/go.mod
+++ b/go.mod
@@ -5,8 +5,11 @@ go 1.20
 require github.com/dotabuff/manta v1.4.2
 
 require (
-	github.com/davecgh/go-spew v1.1.0 // indirect
+	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/golang/protobuf v1.5.2 // indirect
 	github.com/golang/snappy v0.0.3 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
+	github.com/stretchr/testify v1.8.2 // indirect
 	google.golang.org/protobuf v1.26.0 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,7 @@
 github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
+github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/dotabuff/manta v1.4.2 h1:FC2bX6R7mvZzrid9N1ldnqZGHrLwdd2U+liY31EkK00=
 github.com/dotabuff/manta v1.4.2/go.mod h1:LECH//XElrrs1Y/kK39zM22TB0fC2V4jW9aQL+rjCto=
 github.com/golang/protobuf v1.5.0/go.mod h1:FsONVRAS9T7sI+LIUmWTfcYkHO4aIWwzhcaSAoJOfIk=
@@ -12,8 +14,14 @@ github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+github.com/stretchr/objx v0.4.0/go.mod h1:YvHI0jy2hoMjB+UWwv71VJQ9isScKT/TqJzVSSt89Yw=
+github.com/stretchr/objx v0.5.0/go.mod h1:Yh+to48EsGEfYuaHDzXPcE3xhTkx73EhmCGUpEOglKo=
 github.com/stretchr/testify v1.5.1 h1:nOGnQDM7FYENwehXlg/kFVnos3rEvtKTjRvOWSzb6H4=
 github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5cxcmMvtA=
+github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
+github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
+github.com/stretchr/testify v1.8.2 h1:+h33VjcLVPDHtOdpUCuF+7gSuG3yGIftsP1YvFihtJ8=
+github.com/stretchr/testify v1.8.2/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543 h1:E7g+9GITq07hpfrRu66IVDexMakfv52eLZ2CXBWiKr4=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 google.golang.org/protobuf v1.26.0-rc.1/go.mod h1:jlhhOSvTdKEhbULTjvd4ARK9grFBp09yW+WbY/TyQbw=
@@ -22,3 +30,6 @@ google.golang.org/protobuf v1.26.0/go.mod h1:9q0QmTI4eRPtz6boOQmLYwt+qCgq0jsYwAQ
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v2 v2.2.2 h1:ZCJp+EgiOT7lHqUV2J862kp8Qj64Jo6az82+3Td9dZw=
 gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
+gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/rsc/client/valve/replay.go
+++ b/rsc/client/valve/replay.go
@@ -13,54 +13,26 @@ var (
 	ErrDownloadRelpay = fmt.Errorf("failed to download the dota2 replay")
 )
 
-type ReplayDownloader interface {
-	// Download
-	// downloading the replay file is downloaded directly to the
-	// Valve replay proxy using the replayURL.
-	//
-	// replayURL contains the full raw URI to download the replay to the Valve replay proxy,
-	// for example http://replay153.valve.net/570/7132230434_1635105612.dem.bz2
-	// Based on that value, we can download the replay DotA2 file directly using that URL.
-	//
-	// destination parameter specifies the file destination to save the downloaded replay file.
-	Download(ctx context.Context, replayURL string, destination string) error
-}
-
 type replay struct {
 	httpClient *http.Client
 }
 
-func NewReplay(httpClient *http.Client) ReplayDownloader {
+func NewReplay(httpClient *http.Client) *replay {
 	return &replay{
 		httpClient: httpClient,
 	}
 }
 
+// Download
+// downloading the replay file is downloaded directly to the
+// Valve replay proxy using the replayURL.
+//
+// replayURL contains the full raw URI to download the replay to the Valve replay proxy,
+// for example http://replay153.valve.net/570/7132230434_1635105612.dem.bz2
+// Based on that value, we can download the replay DotA2 file directly using that URL.
+//
+// destination parameter specifies the file destination to save the downloaded replay file.
 func (r *replay) Download(ctx context.Context, replayURL string, destination string) error {
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, replayURL, nil)
-
-	if err != nil {
-		return err
-	}
-
-	res, err := r.httpClient.Do(req)
-
-	if err != nil {
-		return err
-	}
-
-	defer res.Body.Close()
-
-	if res.StatusCode != http.StatusOK {
-		return ErrDownloadRelpay
-	}
-
-	body, err := io.ReadAll(res.Body)
-
-	if err != nil {
-		return err
-	}
-
 	fileName := getFileName(replayURL)
 
 	// create location for destination file
@@ -68,14 +40,34 @@ func (r *replay) Download(ctx context.Context, replayURL string, destination str
 	// /tmp/${filename}
 	name := fmt.Sprintf("%s/%s", destination, fileName)
 
-	file, err := os.Create(name)
+	isExist := isReplayAlreadyExist(name)
 
+	if isExist {
+		return nil
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, replayURL, nil)
 	if err != nil {
 		return err
 	}
 
-	_, err = file.Write(body)
+	res, err := r.httpClient.Do(req)
+	if err != nil {
+		return err
+	}
+	defer res.Body.Close()
 
+	if res.StatusCode != http.StatusOK {
+		return ErrDownloadRelpay
+	}
+
+	file, err := os.Create(name)
+	if err != nil {
+		return err
+	}
+	defer file.Close()
+
+	_, err = io.Copy(file, res.Body)
 	if err != nil {
 		return err
 	}
@@ -89,4 +81,15 @@ func getFileName(replayURL string) string {
 	fileName := s[len(s)-1]
 
 	return fileName
+}
+
+// isReplayAlreadyExist
+//
+// given path and file name, check if file is already exist in the path or not
+// if file replay is already exist, then just return immediately.
+// otherwise, need to download it first
+func isReplayAlreadyExist(file string) bool {
+	_, err := os.Stat(file)
+
+	return err == nil
 }

--- a/rsc/client/valve/replay.go
+++ b/rsc/client/valve/replay.go
@@ -1,0 +1,92 @@
+package valve
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"strings"
+)
+
+var (
+	ErrDownloadRelpay = fmt.Errorf("failed to download the dota2 replay")
+)
+
+type ReplayDownloader interface {
+	// Download
+	// downloading the replay file is downloaded directly to the
+	// Valve replay proxy using the replayURL.
+	//
+	// replayURL contains the full raw URI to download the replay to the Valve replay proxy,
+	// for example http://replay153.valve.net/570/7132230434_1635105612.dem.bz2
+	// Based on that value, we can download the replay DotA2 file directly using that URL.
+	//
+	// destination parameter specifies the file destination to save the downloaded replay file.
+	Download(ctx context.Context, replayURL string, destination string) error
+}
+
+type replay struct {
+	httpClient *http.Client
+}
+
+func NewReplay(httpClient *http.Client) ReplayDownloader {
+	return &replay{
+		httpClient: httpClient,
+	}
+}
+
+func (r *replay) Download(ctx context.Context, replayURL string, destination string) error {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, replayURL, nil)
+
+	if err != nil {
+		return err
+	}
+
+	res, err := r.httpClient.Do(req)
+
+	if err != nil {
+		return err
+	}
+
+	defer res.Body.Close()
+
+	if res.StatusCode != http.StatusOK {
+		return ErrDownloadRelpay
+	}
+
+	body, err := io.ReadAll(res.Body)
+
+	if err != nil {
+		return err
+	}
+
+	fileName := getFileName(replayURL)
+
+	// create location for destination file
+	// example:
+	// /tmp/${filename}
+	name := fmt.Sprintf("%s/%s", destination, fileName)
+
+	file, err := os.Create(name)
+
+	if err != nil {
+		return err
+	}
+
+	_, err = file.Write(body)
+
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func getFileName(replayURL string) string {
+	s := strings.Split(replayURL, "/")
+
+	fileName := s[len(s)-1]
+
+	return fileName
+}

--- a/rsc/client/valve/replay_integration_test.go
+++ b/rsc/client/valve/replay_integration_test.go
@@ -1,0 +1,46 @@
+//go:build integration
+// +build integration
+
+package valve
+
+import (
+	"context"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestDownload(t *testing.T) {
+	t.Run("download dota2 replay file should be success", func(t *testing.T) {
+		// this replay url can be found using OpenDota API
+		// for docs how to get the replayURL using OpenDota API
+		// can be read here: https://docs.opendota.com/#tag/matches%2Fpaths%2F~1matches~1%7Bmatch_id%7D%2Fget
+		replayURL := "http://replay153.valve.net/570/7132230434_1635105612.dem.bz2"
+
+		r := NewReplay(http.DefaultClient)
+
+		ctx := context.Background()
+
+		destination := "/tmp"
+
+		err := r.Download(ctx, replayURL, destination)
+
+		assert.NoError(t, err)
+	})
+
+	t.Run("download dota2 replay file should be failed due to invalid replay url", func(t *testing.T) {
+		replayURL := "http://replay153.valve.net/570"
+
+		r := NewReplay(http.DefaultClient)
+
+		ctx := context.Background()
+
+		destination := "/tmp"
+
+		err := r.Download(ctx, replayURL, destination)
+
+		assert.Error(t, err)
+		assert.Equal(t, err, ErrDownloadRelpay)
+	})
+}

--- a/rsc/client/valve/replay_test.go
+++ b/rsc/client/valve/replay_test.go
@@ -1,46 +1,11 @@
+//go:build !integration
+// +build !integration
+
 package valve
 
 import (
-	"context"
-	"net/http"
 	"testing"
-
-	"github.com/stretchr/testify/assert"
 )
-
-func TestDownload(t *testing.T) {
-	t.Run("download dota2 replay file should be success", func(t *testing.T) {
-		// this replay url can be found using OpenDota API
-		// for docs how to get the replayURL using OpenDota API
-		// can be read here: https://docs.opendota.com/#tag/matches%2Fpaths%2F~1matches~1%7Bmatch_id%7D%2Fget
-		replayURL := "http://replay153.valve.net/570/7132230434_1635105612.dem.bz2"
-
-		r := NewReplay(http.DefaultClient)
-
-		ctx := context.Background()
-
-		destination := "/tmp"
-
-		err := r.Download(ctx, replayURL, destination)
-
-		assert.NoError(t, err)
-	})
-
-	t.Run("download dota2 replay file should be failed due to invalid replay url", func(t *testing.T) {
-		replayURL := "http://replay153.valve.net/570"
-
-		r := NewReplay(http.DefaultClient)
-
-		ctx := context.Background()
-
-		destination := "/tmp"
-
-		err := r.Download(ctx, replayURL, destination)
-
-		assert.Error(t, err)
-		assert.Equal(t, err, ErrDownloadRelpay)
-	})
-}
 
 func Test_getFileName(t *testing.T) {
 	type args struct {

--- a/rsc/client/valve/replay_test.go
+++ b/rsc/client/valve/replay_test.go
@@ -1,0 +1,83 @@
+package valve
+
+import (
+	"context"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestDownload(t *testing.T) {
+	t.Run("download dota2 replay file should be success", func(t *testing.T) {
+		// this replay url can be found using OpenDota API
+		// for docs how to get the replayURL using OpenDota API
+		// can be read here: https://docs.opendota.com/#tag/matches%2Fpaths%2F~1matches~1%7Bmatch_id%7D%2Fget
+		replayURL := "http://replay153.valve.net/570/7132230434_1635105612.dem.bz2"
+
+		r := NewReplay(http.DefaultClient)
+
+		ctx := context.Background()
+
+		destination := "/tmp"
+
+		err := r.Download(ctx, replayURL, destination)
+
+		assert.NoError(t, err)
+	})
+
+	t.Run("download dota2 replay file should be failed due to invalid replay url", func(t *testing.T) {
+		replayURL := "http://replay153.valve.net/570"
+
+		r := NewReplay(http.DefaultClient)
+
+		ctx := context.Background()
+
+		destination := "/tmp"
+
+		err := r.Download(ctx, replayURL, destination)
+
+		assert.Error(t, err)
+		assert.Equal(t, err, ErrDownloadRelpay)
+	})
+}
+
+func Test_getFileName(t *testing.T) {
+	type args struct {
+		replayURL string
+	}
+	tests := []struct {
+		name string
+		args args
+		want string
+	}{
+		{
+			name: "get file name from replay url should success",
+			args: args{
+				replayURL: "http://replay153.valve.net/570/7132230434_1635105612.dem.bz2",
+			},
+			want: "7132230434_1635105612.dem.bz2",
+		},
+		{
+			name: "get file name from replay url should success",
+			args: args{
+				replayURL: "http://replay153.valve.net/570/7132230435_1635105612.dem.bz2",
+			},
+			want: "7132230435_1635105612.dem.bz2",
+		},
+		{
+			name: "get file name from replay url should success",
+			args: args{
+				replayURL: "http://replay153.valve.net/570/7132230455_1635105612.dem.bz2",
+			},
+			want: "7132230455_1635105612.dem.bz2",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := getFileName(tt.args.replayURL); got != tt.want {
+				t.Errorf("getFileName() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Description
Add functionality to download DotA2 replay files from the Valve proxy website. A sample `replay_url` that can be downloaded is http://replay153.valve.net/570/7132230434_1635105612.dem.bz2. In the future, we plan to use `OpenDota API` to obtain the `replay_url` based on the `match_id` of our public match in DotA2. However, for the time being, we cannot use the `OpenDota API` because it requires a linked credit card.

## How this has been tested
This functionality has been tested through the unit test I created in `replay_test.go`. It request to Valve to download the file and saves it to a destination we define.