### PR TITLE
feat: add integration with open dota api

### DIFF
--- a/rsc/client/opendota/match.go
+++ b/rsc/client/opendota/match.go
@@ -1,0 +1,58 @@
+package opendota
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+)
+
+var (
+	ErrFetchMatchDetail = fmt.Errorf("failed to fetch match detail")
+)
+
+type OpenDotaAPI struct {
+	httpClient *http.Client
+	APIURL     string
+}
+
+func NewMatchAPI(httpClient *http.Client, APIURL string) *OpenDotaAPI {
+	return &OpenDotaAPI{
+		httpClient: httpClient,
+		APIURL:     APIURL,
+	}
+}
+
+func (m *OpenDotaAPI) FetchMatchDetail(ctx context.Context, matchID int64) (MatchDetail, error) {
+	matchDetailURL := fmt.Sprintf("%s/matches/%d", m.APIURL, matchID)
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, matchDetailURL, nil)
+	if err != nil {
+		return MatchDetail{}, err
+	}
+
+	res, err := m.httpClient.Do(req)
+	if err != nil {
+		return MatchDetail{}, err
+	}
+	defer res.Body.Close()
+
+	if res.StatusCode != http.StatusOK {
+		return MatchDetail{}, ErrFetchMatchDetail
+	}
+
+	body, err := io.ReadAll(res.Body)
+	if err != nil {
+		return MatchDetail{}, err
+	}
+
+	var matchDetail MatchDetail
+
+	err = json.Unmarshal(body, &matchDetail)
+	if err != nil {
+		return MatchDetail{}, err
+	}
+
+	return matchDetail, nil
+}

--- a/rsc/client/opendota/match.go
+++ b/rsc/client/opendota/match.go
@@ -14,18 +14,18 @@ var (
 
 type OpenDotaAPI struct {
 	httpClient *http.Client
-	APIURL     string
+	BaseURL    string
 }
 
-func NewMatchAPI(httpClient *http.Client, APIURL string) *OpenDotaAPI {
+func NewMatchAPI(httpClient *http.Client, BaseURL string) *OpenDotaAPI {
 	return &OpenDotaAPI{
 		httpClient: httpClient,
-		APIURL:     APIURL,
+		BaseURL:    BaseURL,
 	}
 }
 
 func (m *OpenDotaAPI) FetchMatchDetail(ctx context.Context, matchID int64) (MatchDetail, error) {
-	matchDetailURL := fmt.Sprintf("%s/matches/%d", m.APIURL, matchID)
+	matchDetailURL := fmt.Sprintf("%s/matches/%d", m.BaseURL, matchID)
 
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, matchDetailURL, nil)
 	if err != nil {

--- a/rsc/client/opendota/match_integration_test.go
+++ b/rsc/client/opendota/match_integration_test.go
@@ -1,0 +1,44 @@
+//go:build integration
+// +build integration
+
+package opendota
+
+import (
+	"context"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestFetchMatchDetail(t *testing.T) {
+	ctx := context.Background()
+	t.Run("fetch match detail dota2 should be success", func(t *testing.T) {
+		openDotaAPIURL := "https://api.opendota.com/api"
+		httpClient := http.DefaultClient
+
+		openDotaAPI := NewMatchAPI(httpClient, openDotaAPIURL)
+
+		// my personal match id
+		matchID := 271145478
+
+		matchDetail, err := openDotaAPI.FetchMatchDetail(ctx, int64(matchID))
+
+		assert.NoError(t, err)
+		assert.NotEmpty(t, matchDetail)
+	})
+
+	t.Run("fetch match detail dota2 should failed because match id is not found", func(t *testing.T) {
+		openDotaAPIURL := "https://api.opendota.com/api"
+		httpClient := http.DefaultClient
+
+		openDotaAPI := NewMatchAPI(httpClient, openDotaAPIURL)
+
+		matchID := 0
+
+		matchDetail, err := openDotaAPI.FetchMatchDetail(ctx, int64(matchID))
+
+		assert.Error(t, err)
+		assert.Empty(t, matchDetail)
+	})
+}

--- a/rsc/client/opendota/match_integration_test.go
+++ b/rsc/client/opendota/match_integration_test.go
@@ -13,12 +13,12 @@ import (
 
 func TestFetchMatchDetail(t *testing.T) {
 	ctx := context.Background()
+	openDotaAPIURL := "https://api.opendota.com/api"
+	httpClient := http.DefaultClient
+
+	openDotaAPI := NewMatchAPI(httpClient, openDotaAPIURL)
+
 	t.Run("fetch match detail dota2 should be success", func(t *testing.T) {
-		openDotaAPIURL := "https://api.opendota.com/api"
-		httpClient := http.DefaultClient
-
-		openDotaAPI := NewMatchAPI(httpClient, openDotaAPIURL)
-
 		// my personal match id
 		matchID := 271145478
 
@@ -29,11 +29,6 @@ func TestFetchMatchDetail(t *testing.T) {
 	})
 
 	t.Run("fetch match detail dota2 should failed because match id is not found", func(t *testing.T) {
-		openDotaAPIURL := "https://api.opendota.com/api"
-		httpClient := http.DefaultClient
-
-		openDotaAPI := NewMatchAPI(httpClient, openDotaAPIURL)
-
 		matchID := 0
 
 		matchDetail, err := openDotaAPI.FetchMatchDetail(ctx, int64(matchID))

--- a/rsc/client/opendota/type.go
+++ b/rsc/client/opendota/type.go
@@ -1,0 +1,7 @@
+package opendota
+
+type MatchDetail struct {
+	ReplayURL string `json:"replay_url"`
+	MatchID   int64  `json:"match_id"`
+	Region    int32  `json:"region"`
+}


### PR DESCRIPTION
## Description
We added integration with OpenDota API to retrieve details of a match based on its `match_id`. This integration helps us to download the replay from Valve directly, as the resulting match details contain a `replay_url` field with a URL to download the replay file from Valve.